### PR TITLE
Allow multiple CORS origins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ console.log(Constants);
 export const app = Express();
 
 const corsOptions: Cors.CorsOptions = {
-    origin: Constants.ORIGIN,
+    origin: Constants.ORIGINS.split(";"),
     exposedHeaders: ["Location", "Set-Cookie"],
     credentials: true,
     maxAge: 604800,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,6 +7,6 @@ function throwEnv(name: string) : string {
 export const PORT = parseInt(process.env["PORT"] ?? throwEnv("PORT"));
 export const SECRET = process.env["SECRET"] ?? throwEnv("SECRET");
 export const PG_URL = process.env["PG_URL"] ?? throwEnv("PG_URL");
-export const ORIGIN = process.env["ORIGIN"] ?? "http://localhost:5173";
+export const ORIGINS = process.env["ORIGINS"] ?? "http://localhost:3000";
 export const HTTPS = process.env["HTTPS"] === "true";
 export const NODE_ENV = process.env["NODE_ENV"] ?? "production";


### PR DESCRIPTION
This way, we can allow `http://localhost:3000` for testing, but also allow an actual URL (presumably we will eventually set up GitHub Pages).

Tests are passing (`npm run test`).